### PR TITLE
Fix reproducible 40M and 80M inference setup

### DIFF
--- a/Hojo-TTS-Light-40M/README.md
+++ b/Hojo-TTS-Light-40M/README.md
@@ -12,13 +12,16 @@ https://github.com/user-attachments/assets/79023517-80e3-4d67-837e-c4b4f9367a0b
 - **15 voices** via opaque IDs in `Hojo-TTS-Light-40M-voice.npz` (e.g. `hojo_en_m_02`)
 - **CPU or GPU** (ONNX Runtime)
 - **Up to 4096 LM tokens** per utterance (`max_position_embeddings` in `config.json`)
-- Dependencies: `numpy`, `soundfile`, `tokenizers`, `onnxruntime`, `huggingface_hub` (for `--repo-id` / `hf download`)
+- Dependencies: `numpy`, `soundfile`, `tokenizers`, `onnx`, `onnxruntime`, `huggingface_hub` (for `--repo-id` / `hf download`), and SOCKS proxy support
 
 ## Quick start
 
 ```bash
 pip install -r requirements.txt
 ```
+
+The requirements include `httpx[socks]`, so `--repo-id` also works when
+`HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` points to a SOCKS proxy.
 
 ### Get models
 
@@ -76,7 +79,8 @@ tts.generate_to_file("Hello.", "out.wav", voice="hojo_en_m_02")
 
 ## Voices
 
-Use `--voice` with one of the opaque IDs below (`hojo_{lang}_{sex}_{nn}`; `sex` is `f` / `m` in the ID, `female` / `male` in the table):
+Use `--voice` with one of the opaque IDs below (`hojo_{lang}_{sex}_{nn}`;
+`sex` is `f` / `m` / `u` in the ID, where `u` means unspecified):
 
 | Voice ID | Language | Sex |
 |----------|----------|-----|
@@ -89,12 +93,12 @@ Use `--voice` with one of the opaque IDs below (`hojo_{lang}_{sex}_{nn}`; `sex` 
 | `hojo_en_f_05` | en | female |
 | `hojo_en_f_06` | en | female |
 | `hojo_en_f_07` | en | female |
-| `hojo_en_f_08` | en | female |
 | `hojo_en_m_01` | en | male |
 | `hojo_en_m_02` | en | male |
 | `hojo_en_m_03` | en | male |
 | `hojo_en_m_04` | en | male |
 | `hojo_en_m_05` | en | male |
+| `hojo_en_u_01` | en | unspecified |
 
 Default voice: **`hojo_en_m_02`**.
 

--- a/Hojo-TTS-Light-40M/onnx_model.py
+++ b/Hojo-TTS-Light-40M/onnx_model.py
@@ -157,8 +157,12 @@ def _ort_model_source(model_path: str):
     """
     try:
         import onnx
-    except ImportError:
-        return model_path
+    except ImportError as exc:
+        raise RuntimeError(
+            "The 'onnx' package is required to load the published BF16 model "
+            "bundle. Install Hojo-TTS-Light-40M/requirements.txt or run "
+            "'pip install onnx'."
+        ) from exc
 
     model = onnx.load(model_path, load_external_data=True)
     if not _onnx_contains_bfloat16(model):

--- a/Hojo-TTS-Light-40M/requirements.txt
+++ b/Hojo-TTS-Light-40M/requirements.txt
@@ -5,6 +5,7 @@
 numpy>=1.24
 soundfile>=0.12
 tokenizers>=0.15
+onnx>=1.14
 
 # CPU:
 onnxruntime>=1.17
@@ -12,3 +13,5 @@ onnxruntime>=1.17
 # onnxruntime-gpu>=1.17
 
 huggingface_hub>=0.23
+# Required when HTTP(S)_PROXY or ALL_PROXY uses a socks:// URL.
+httpx[socks]>=0.23

--- a/Hojo-TTS-Light-80M/README.md
+++ b/Hojo-TTS-Light-80M/README.md
@@ -30,7 +30,7 @@ https://github.com/user-attachments/assets/8501450e-4942-4eea-a8d9-4923d42a7bba
 
 ```bash
 git clone https://github.com/HojoAI/Hojo-TTS-Light.git
-cd Hojo-TTS-Light
+cd Hojo-TTS-Light/Hojo-TTS-Light-80M
 # Create a conda environment named hojo-tts with Python 3.12
 conda create -n hojo-tts python=3.12 -y
 
@@ -41,11 +41,18 @@ conda activate hojo-tts
 pip install -r requirements.txt
 ```
 
+The default requirements install the CPU builds used by the command below. For
+CUDA, replace `onnxruntime` with `onnxruntime-gpu`, install the PyTorch build
+matching your CUDA version from the
+[PyTorch installation guide](https://pytorch.org/get-started/locally/), and add
+`--provider cuda` to the inference command.
+
 ### Download ONNX Models from HuggingFace
 
 ```bash
-pip install -U "huggingface_hub[cli]"
-hf download HojoAI/Hojo-TTS-Light   --repo-type model   --local-dir ./models
+hf download HojoAI/Hojo-TTS-Light \
+  --repo-type model \
+  --local-dir ./models
 ```
 
 ### Run Inference

--- a/Hojo-TTS-Light-80M/onnx_model.py
+++ b/Hojo-TTS-Light-80M/onnx_model.py
@@ -174,8 +174,12 @@ def _ort_model_source(model_path: str, *, promote_bf16_for_cpu: bool):
         return model_path
     try:
         import onnx
-    except ImportError:
-        return model_path
+    except ImportError as exc:
+        raise RuntimeError(
+            "The 'onnx' package is required to promote the published BF16 "
+            "model graph for CPU inference. Install "
+            "Hojo-TTS-Light-80M/requirements.txt or run 'pip install onnx'."
+        ) from exc
     model = onnx.load(model_path, load_external_data=True)
     if not _onnx_contains_bfloat16(model):
         return model_path

--- a/Hojo-TTS-Light-80M/requirements.txt
+++ b/Hojo-TTS-Light-80M/requirements.txt
@@ -1,8 +1,13 @@
-numpy==1.24.4
-onnxruntime==1.23.2
-optimum==2.1.0
-optimum-onnx==0.1.0
-soundfile==0.13.1
-torch==2.8.0+cu128
-torchaudio==2.8.0+cu128
-transformers==5.2.0
+# Runtime dependencies for Python 3.12 and CPU inference.
+# For CUDA-specific ONNX Runtime and PyTorch installation, see README.md.
+numpy>=1.26
+onnx>=1.16
+onnxruntime>=1.23
+soundfile>=0.13
+torch>=2.8
+librosa>=0.11
+scipy>=1.11
+tokenizers>=0.15
+huggingface_hub>=0.34
+# Supports `hf download` when a socks:// proxy is configured.
+httpx[socks]>=0.23

--- a/tests/test_onnx_dependency.py
+++ b/tests/test_onnx_dependency.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, relative_path: str):
+    spec = importlib.util.spec_from_file_location(
+        name, REPOSITORY_ROOT / relative_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {relative_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MODEL_40M = load_module("hojo_40m_onnx_model", "Hojo-TTS-Light-40M/onnx_model.py")
+MODEL_80M = load_module("hojo_80m_onnx_model", "Hojo-TTS-Light-80M/onnx_model.py")
+
+
+def import_without_onnx(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "onnx":
+        raise ImportError("onnx intentionally hidden by test")
+    return ORIGINAL_IMPORT(name, globals, locals, fromlist, level)
+
+
+ORIGINAL_IMPORT = builtins.__import__
+
+
+class MissingOnnxDependencyTests(unittest.TestCase):
+    def test_40m_reports_missing_onnx(self):
+        with mock.patch("builtins.__import__", side_effect=import_without_onnx):
+            with self.assertRaisesRegex(RuntimeError, "pip install onnx"):
+                MODEL_40M._ort_model_source("published-bf16-model.onnx")
+
+    def test_80m_cpu_reports_missing_onnx(self):
+        with mock.patch("builtins.__import__", side_effect=import_without_onnx):
+            with self.assertRaisesRegex(RuntimeError, "pip install onnx"):
+                MODEL_80M._ort_model_source(
+                    "published-bf16-model.onnx", promote_bf16_for_cpu=True
+                )
+
+    def test_80m_cuda_does_not_require_graph_promotion(self):
+        model_path = "published-bf16-model.onnx"
+        with mock.patch("builtins.__import__", side_effect=import_without_onnx):
+            self.assertEqual(
+                MODEL_80M._ort_model_source(
+                    model_path, promote_bf16_for_cpu=False
+                ),
+                model_path,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR makes the documented 40M and 80M inference flows reproducible from clean Python environments.

- declare `onnx` for BF16-to-FP32 graph promotion and report an actionable error instead of silently passing an incompatible graph to ONNX Runtime;
- include SOCKS proxy support for Hugging Face downloads;
- align the 40M voice table with the 15 IDs in the published model bundle;
- replace the unsatisfiable, CUDA-only 80M dependency pins with the packages actually imported by the inference runtime;
- fix the 80M working directory, model download, and CPU/CUDA instructions;
- add regression coverage for missing `onnx` behavior on 40M CPU, 80M CPU, and the 80M CUDA bypass path.

## User impact and root cause

With the current 40M requirements, `onnx` is absent. `_ort_model_source()` catches that import error and silently returns the published BF16 graph, so Apple Silicon CPU users receive `Could not find an implementation for Where(16)` instead of a missing-package message. A SOCKS proxy causes the earlier `--repo-id` download to fail because `socksio` is also absent.

The 80M requirements cannot resolve because `optimum-onnx==0.1.0` requires `transformers<4.58` while the file pins `transformers==5.2.0`. It also pins CUDA-local PyTorch versions that do not exist on macOS, while omitting `onnx`, `librosa`, `scipy`, and `tokenizers`, which the runtime imports. The README then runs `pip install -r requirements.txt` and `python infer.py` from the repository root, where neither file exists.

## Validation

Tested on macOS 26.1, Apple M4, 24 GB:

- clean Python 3.11 environment installed the updated 40M requirements (including `onnx` and `socksio`);
- 40M `--repo-id` succeeded through the configured SOCKS proxy and generated a valid 24 kHz mono PCM WAV;
- 15/15 published 40M voices generated finite, non-silent output;
- four 40M short/long Chinese, English, and mixed-language cases produced RTF 0.21-0.26 on CPU;
- the README voice table now exactly matches all 15 IDs in `HojoAI/Hojo-TTS-Light-40M@c3cf21c`;
- 40M requirements resolved for Python 3.10, 3.11, and 3.12;
- clean Python 3.12 environment installed the updated 80M requirements on macOS arm64;
- the published 437 MB 80M ONNX bundle generated a valid, non-silent 24 kHz mono PCM WAV using the corrected working-directory flow (about 2.43 GB maximum RSS in the final run);
- `python -m unittest discover -s tests -v`: 3 tests passed;
- `git diff --check`: passed.

Closes #2
Closes #3
Closes #4
Closes #5
